### PR TITLE
Fix duplicate README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,5 +137,3 @@ To modify the merge behavior:
 2. **GitHub authentication failed:** Check your token permissions and expiration
 3. **No repositories found:** Verify your username and token have access to repos
 4. **Merge failures:** Check the detailed logs for specific error messages
-# auto-merger
-# auto-merger


### PR DESCRIPTION
## Summary
- clean up extra heading at end of README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6871220c4958833287d16645ab59088c