### PR TITLE
Align force-merge log path

### DIFF
--- a/aggro.sh
+++ b/aggro.sh
@@ -14,7 +14,7 @@ if [ -z "$GITHUB_TOKEN" ] || [ -z "$GITHUB_USERNAME" ]; then
 fi
 
 WORKSPACE="/tmp/force-merge"
-LOG_FILE="/tmp/force-merge.log"
+LOG_FILE="/var/log/force-merge.log"
 
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] FORCE-MERGE: $1" | tee -a "$LOG_FILE"


### PR DESCRIPTION
## Summary
- log aggressive merge output to `/var/log/force-merge.log`

## Testing
- `bash -n aggro.sh`
- `bash -n check-log-size.sh`
- `source /opt/scripts/auto-merge.env` *(fails: No such file or directory)*
- `./setup-env.sh` *(fails: required vars not set)*
- `./check-log-size.sh` *(warns missing log file)*


------
https://chatgpt.com/codex/tasks/task_e_68712204ce7083328a41c55cc6276860