### PR TITLE
Fix repo jq output

### DIFF
--- a/aggro.sh
+++ b/aggro.sh
@@ -35,7 +35,7 @@ setup() {
 # Get all repos
 get_all_repos() {
     gh repo list "$GITHUB_USERNAME" --limit 1000 --json name,url,defaultBranchRef | \
-    jq -r '.[] | "\(.name)|\(.url)|\((.defaultBranchRef.name))"'
+    jq -r '.[] | "\(.name)|\(.url)|\(.defaultBranchRef.name)"'
 }
 
 # Force merge all PRs in a repo


### PR DESCRIPTION
## Summary
- list repositories with fixed jq expression

## Testing
- `./setup-env.sh` *(fails: required env vars not set)*
- `./check-log-size.sh`
- `bash -n aggro.sh`

------
https://chatgpt.com/codex/tasks/task_e_687122047ce88332954b009b3202aae6