### PR TITLE
Fix jq check in merge prereqs

### DIFF
--- a/merge.sh
+++ b/merge.sh
@@ -40,11 +40,15 @@ check_prerequisites() {
     if ! command -v gh &> /dev/null; then
         error_exit "GitHub CLI (gh) is not installed. Install it first."
     fi
-    
+
     if ! command -v git &> /dev/null; then
         error_exit "Git is not installed"
     fi
-    
+
+    if ! command -v jq &> /dev/null; then
+        error_exit "jq is not installed"
+    fi
+
     # Authenticate with GitHub CLI
     echo "$GITHUB_TOKEN" | gh auth login --with-token
 }


### PR DESCRIPTION
## Summary
- verify `jq` dependency in `check_prerequisites`

## Testing
- `./setup-env.sh`
- `./check-log-size.sh`

------
https://chatgpt.com/codex/tasks/task_e_687121f9dbdc833284c343ef87f2ab5f