### PR TITLE
Add parallel option to merge script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
    ```bash
    #!/bin/bash
    source /opt/scripts/auto-merge.env
-   /opt/scripts/merge.sh
+   /opt/scripts/merge.sh --parallel 4
    ```
    
    Make it executable:
@@ -97,6 +97,7 @@ You can modify these variables in the script:
 - `LOG_FILE`: Where to store detailed logs
 - `REPO_DIR`: Temporary directory for cloning repos
 - `MAX_RETRIES`: Number of retry attempts for failed operations
+- `--parallel [N]`: Enable parallel processing with up to `N` concurrent jobs. If `N` is omitted, the default is 4.
 
 ## Monitoring
 


### PR DESCRIPTION
## Summary
- add `--parallel` flag with configurable job limit
- prefix log lines with repository name for clarity
- update wrapper script example and docs

## Testing
- `bash -n merge.sh`
- `./setup-env.sh` *(fails: no output)*
- `./check-log-size.sh` *(fails: no output)*
- `bash merge.sh --parallel 2` *(fails: token not set)*

------
https://chatgpt.com/codex/tasks/task_e_68712dbf08848332b832afa03f42c1a3