### PR TITLE
Fix env variable usage in update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@
    export GITHUB_USERNAME="your_github_username"
    ```
 
+   **Note:** All scripts, including `update-automerge.sh`, expect the variable
+   name `GITHUB_TOKEN` exactly as shown. Do not use `GITHUB_TOKEN_VALUE`.
+
 3. **Validate your environment:**
    ```bash
    ./setup-env.sh

--- a/update-automerge.sh
+++ b/update-automerge.sh
@@ -33,6 +33,16 @@ fi
 # Make sure scripts are executable
 chmod +x aggro.sh check-log-size.sh setup-env.sh 2>/dev/null
 
+# Source environment and validate
+if [ -f /opt/scripts/auto-merge.env ]; then
+    # shellcheck source=/dev/null
+    source /opt/scripts/auto-merge.env
+fi
+./setup-env.sh || {
+    log "ERROR: Environment setup failed"
+    exit 1
+}
+
 # Backup current crontab
 crontab -l > /tmp/crontab_backup_$(date +%Y%m%d_%H%M%S) 2>/dev/null
 
@@ -40,7 +50,7 @@ crontab -l > /tmp/crontab_backup_$(date +%Y%m%d_%H%M%S) 2>/dev/null
 crontab -l 2>/dev/null | grep -v "aggro.sh" > /tmp/new_crontab_temp
 
 # Add the updated automerge cronjob (every minute)
-echo "* * * * * cd $REPO_DIR && GITHUB_TOKEN=\"$GITHUB_TOKEN_VALUE\" GITHUB_USERNAME=\"$GITHUB_USERNAME\" ./aggro.sh >> /var/log/force-merge.log 2>&1" >> /tmp/new_crontab_temp
+echo "* * * * * cd $REPO_DIR && GITHUB_TOKEN=\"$GITHUB_TOKEN\" GITHUB_USERNAME=\"$GITHUB_USERNAME\" ./aggro.sh >> /var/log/force-merge.log 2>&1" >> /tmp/new_crontab_temp
 
 # Install the new crontab
 crontab /tmp/new_crontab_temp


### PR DESCRIPTION
## Summary
- update README about using `GITHUB_TOKEN`
- load environment in `update-automerge.sh`
- use `GITHUB_TOKEN` when writing cron job

## Testing
- `source /opt/scripts/auto-merge.env` *(fails: no such file)*
- `./setup-env.sh` *(fails: env vars not set)*
- `./check-log-size.sh` *(fails: log file missing)*

------
https://chatgpt.com/codex/tasks/task_e_68712dbc8ef48332b023cbac0e4b9c86