### PR TITLE
Add logrotate config for force-merge logs

### DIFF
--- a/MONITORING.md
+++ b/MONITORING.md
@@ -37,7 +37,7 @@ wc -l /var/log/force-merge.log
 
 #### Remediation Actions
 1. **Immediate**: Rotate current log file
-2. **Short-term**: Implement log rotation (logrotate)
+2. **Short-term**: Log rotation now runs via `/etc/logrotate.d/force-merge`
 3. **Long-term**: Set up automated cleanup and archival
 
 ### 2. Disk Space Monitoring
@@ -54,7 +54,9 @@ Create `/etc/logrotate.d/force-merge`:
     missingok
     notifempty
     postrotate
-        # Signal process to reopen log file if needed
+        # Signal running merge scripts to reopen the log file
+        pkill -HUP -f aggro.sh || true
+        pkill -HUP -f merge.sh || true
     endscript
 }
 ```

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can modify these variables in the script:
 
 **Recommended actions:**
 - Monitor log file size weekly: `ls -lh /var/log/force-merge.log`
-- Set up log rotation if the file grows large (>100MB)
+- Log rotation is now configured via `/etc/logrotate.d/force-merge` (daily, keep 7)
 - Consider implementing automated log cleanup for files older than 30 days
 - Add disk space monitoring alerts for the `/var/log` directory
 
@@ -127,6 +127,25 @@ df -h /var/log
 
 # Archive old logs (example)
 sudo gzip /var/log/force-merge.log.old
+```
+
+### Log Rotation Setup
+
+Daily rotation for `/var/log/force-merge.log` is configured via `/etc/logrotate.d/force-merge`:
+
+```logrotate
+/var/log/force-merge.log {
+    daily
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    notifempty
+    postrotate
+        pkill -HUP -f aggro.sh || true
+        pkill -HUP -f merge.sh || true
+    endscript
+}
 ```
 
 ## Safety Features

--- a/etc/logrotate.d/force-merge
+++ b/etc/logrotate.d/force-merge
@@ -1,0 +1,13 @@
+/var/log/force-merge.log {
+    daily
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    notifempty
+    postrotate
+        # Signal any running merge scripts to reopen log file
+        pkill -HUP -f aggro.sh || true
+        pkill -HUP -f merge.sh || true
+    endscript
+}


### PR DESCRIPTION
## Summary
- add `/etc/logrotate.d/force-merge` with daily rotation and HUP signalling
- document log rotation steps in README and MONITORING guides

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68712dbace888332b9e638cebad8fd7f