### PR TITLE
Use App ID for github-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@
    
    Add your configuration:
    ```bash
-   export GITHUB_TOKEN="your_github_personal_access_token_here"
-   export GITHUB_USERNAME="your_github_username"
+    export GITHUB_TOKEN="your_github_personal_access_token_here"
+    export GITHUB_USERNAME="your_github_username"
+    export GITHUB_APP_ID="your_github_app_id"
    ```
 
 3. **Validate your environment:**

--- a/github-app-auth.sh
+++ b/github-app-auth.sh
@@ -6,7 +6,9 @@
 set -euo pipefail
 
 # Configuration
-CLIENT_ID="Iv23liEdil5KNk2fcxh3"  # Using Client ID instead of App ID
+# App ID for generating the JWT. It can be provided via the GITHUB_APP_ID
+# environment variable. Replace the placeholder with your real App ID.
+APP_ID="${GITHUB_APP_ID:-123456}"
 PRIVATE_KEY_PATH="/root/automerge/github-app-private-key.pem"
 GITHUB_USERNAME="c1nderscript"
 
@@ -27,7 +29,7 @@ b64enc() {
 
 # Function to generate JWT using GitHub's recommended approach
 generate_jwt() {
-    local client_id="$1"
+    local app_id="$1"
     local private_key_path="$2"
     
     # Get current time
@@ -49,7 +51,7 @@ generate_jwt() {
     local payload_json="{
         \"iat\":${iat},
         \"exp\":${exp},
-        \"iss\":\"${client_id}\"
+        \"iss\":\"${app_id}\"
     }"
     local payload=$(echo -n "$payload_json" | b64enc)
     
@@ -110,8 +112,8 @@ authenticate() {
     fi
     
     # Generate JWT
-    log "Generating JWT with Client ID: $CLIENT_ID"
-    local jwt=$(generate_jwt "$CLIENT_ID" "$PRIVATE_KEY_PATH")
+    log "Generating JWT with App ID: $APP_ID"
+    local jwt=$(generate_jwt "$APP_ID" "$PRIVATE_KEY_PATH")
     
     if [ -z "$jwt" ]; then
         log "Error: Failed to generate JWT"


### PR DESCRIPTION
## Summary
- use `APP_ID` variable in `github-app-auth.sh`
- read App ID from `GITHUB_APP_ID` environment variable
- add App ID to JWT payload
- update README example to include `GITHUB_APP_ID`

## Testing
- `./setup-env.sh` *(fails: required environment variables not set)*
- `./check-log-size.sh` *(fails: log file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68712db159048332adde3d11252707f9