### PR TITLE
Add configurable GitHub App key path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ auto-merger/
 # Required environment variables (set in /opt/scripts/auto-merge.env)
 export GITHUB_TOKEN="your_github_personal_access_token_here"
 export GITHUB_USERNAME="your_github_username"
+export GITHUB_APP_KEY="/root/automerge/github-app-private-key.pem"  # path to GitHub App private key
 ```
 
 ### Safety Features

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
    ```bash
    export GITHUB_TOKEN="your_github_personal_access_token_here"
    export GITHUB_USERNAME="your_github_username"
+   export GITHUB_APP_KEY="/root/automerge/github-app-private-key.pem" # optional
    ```
 
 3. **Validate your environment:**

--- a/github-app-auth.sh
+++ b/github-app-auth.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 
 # Configuration
 CLIENT_ID="Iv23liEdil5KNk2fcxh3"  # Using Client ID instead of App ID
-PRIVATE_KEY_PATH="/root/automerge/github-app-private-key.pem"
+# Allow override via GITHUB_APP_KEY environment variable
+PRIVATE_KEY_PATH="${GITHUB_APP_KEY:-/root/automerge/github-app-private-key.pem}"
 GITHUB_USERNAME="c1nderscript"
 
 # Colors for output


### PR DESCRIPTION
## Summary
- allow overriding the private key path in `github-app-auth.sh`
- mention `GITHUB_APP_KEY` in setup instructions
- document the environment variable in `AGENTS.md`

## Testing
- `bash -n github-app-auth.sh`
- `bash -n merge.sh`


------
https://chatgpt.com/codex/tasks/task_e_68712dac12608332a627e50ff3287113