### PR TITLE
Add log size check on script startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ df -h /var/log
 sudo gzip /var/log/force-merge.log.old
 ```
 
+`merge.sh` and `aggro.sh` automatically invoke `check-log-size.sh` at startup.
+If the log file exceeds the critical threshold, the script exits without
+performing merges. Set `SKIP_LOG_SIZE_CHECK=1` to bypass this check when
+testing.
+
 ## Safety Features
 
 The script includes several safety measures:

--- a/README.md.backup
+++ b/README.md.backup
@@ -92,6 +92,10 @@ You can modify these variables in the script:
 - **Detailed logs:** `tail -f /tmp/auto-merge.log`
 - **Test manually:** `/opt/scripts/auto-merge-wrapper.sh`
 
+`merge.sh` and `aggro.sh` run `check-log-size.sh` automatically before merging.
+If the log file exceeds the critical threshold the process stops. Use
+`SKIP_LOG_SIZE_CHECK=1` to bypass this check when testing.
+
 ## Safety Features
 
 The script includes several safety measures:

--- a/aggro.sh
+++ b/aggro.sh
@@ -21,6 +21,16 @@ fi
 WORKSPACE="/tmp/force-merge"
 LOG_FILE="/var/log/force-merge.log"
 
+# Run log size check unless explicitly disabled
+if [ -z "$SKIP_LOG_SIZE_CHECK" ]; then
+    "$SCRIPT_DIR/check-log-size.sh"
+    rc=$?
+    if [ "$rc" -eq 2 ]; then
+        echo "CRITICAL: Log size exceeded threshold. Exiting." | tee -a "$LOG_FILE"
+        exit 1
+    fi
+fi
+
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] FORCE-MERGE: $1" | tee -a "$LOG_FILE"
 }

--- a/merge.sh
+++ b/merge.sh
@@ -16,6 +16,16 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+# Automatically check log size unless explicitly skipped
+if [ -z "$SKIP_LOG_SIZE_CHECK" ]; then
+    ./check-log-size.sh
+    rc=$?
+    if [ "$rc" -eq 2 ]; then
+        echo -e "${RED}Critical log size threshold exceeded. Aborting merge.${NC}"
+        exit 1
+    fi
+fi
+
 # Logging function
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"


### PR DESCRIPTION
## Summary
- automatically run `check-log-size.sh` at the start of `merge.sh` and `aggro.sh`
- abort merges if the log file exceeds the critical limit
- allow skipping the check with `SKIP_LOG_SIZE_CHECK=1`
- document the new behaviour in README

## Testing
- `bash -n merge.sh`
- `bash -n aggro.sh`
- `./check-log-size.sh | head -n 3`

------
https://chatgpt.com/codex/tasks/task_e_68712dad23a0833298e92e0ec305fec8