### PR TITLE
store token in opt

### DIFF
--- a/aggro.sh
+++ b/aggro.sh
@@ -13,7 +13,7 @@ if ! authenticate; then
     export GITHUB_TOKEN="${GITHUB_TOKEN_FALLBACK:-}"
     export GITHUB_USERNAME="c1nderscript"
 else
-    source /tmp/github-app-token.env
+    source /opt/scripts/github-app-token.env
     export GITHUB_USERNAME="c1nderscript"
     echo "Using GitHub App authentication with higher rate limits"
 fi

--- a/github-app-auth.sh
+++ b/github-app-auth.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 CLIENT_ID="Iv23liEdil5KNk2fcxh3"  # Using Client ID instead of App ID
 PRIVATE_KEY_PATH="/root/automerge/github-app-private-key.pem"
 GITHUB_USERNAME="c1nderscript"
+# Location to write the authentication token
+TOKEN_FILE="/opt/scripts/github-app-token.env"
 
 # Colors for output
 RED='\033[0;31m'
@@ -161,12 +163,13 @@ authenticate() {
     export GITHUB_INSTALLATION_ID="$installation_id"
     
     # Save to file for other scripts to use
-    echo "export GITHUB_APP_TOKEN=\"$access_token\"" > /tmp/github-app-token.env
-    echo "export GITHUB_INSTALLATION_ID=\"$installation_id\"" >> /tmp/github-app-token.env
-    echo "export GITHUB_TOKEN=\"$access_token\"" >> /tmp/github-app-token.env  # For compatibility
-    chmod 600 /tmp/github-app-token.env
-    
-    log "Token saved to /tmp/github-app-token.env"
+    mkdir -p "$(dirname "$TOKEN_FILE")"
+    echo "export GITHUB_APP_TOKEN=\"$access_token\"" > "$TOKEN_FILE"
+    echo "export GITHUB_INSTALLATION_ID=\"$installation_id\"" >> "$TOKEN_FILE"
+    echo "export GITHUB_TOKEN=\"$access_token\"" >> "$TOKEN_FILE"  # For compatibility
+    chmod 600 "$TOKEN_FILE"
+
+    log "Token saved to $TOKEN_FILE"
     
     # Test the installation token
     log "Testing installation access token..."


### PR DESCRIPTION
## Summary
- store the GitHub app token under `/opt/scripts` instead of `/tmp`
- update `aggro.sh` to source the token from the new location

## Testing
- `bash -n github-app-auth.sh`
- `bash -n aggro.sh`
- `./setup-env.sh` *(fails: auto-merge.env not found)*
- `./check-log-size.sh`

------
https://chatgpt.com/codex/tasks/task_e_68712da121c88332a37e902683fbef8d