### PR TITLE
Add strict mode and fallback token docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
    ```bash
    export GITHUB_TOKEN="your_github_personal_access_token_here"
    export GITHUB_USERNAME="your_github_username"
+   # Optional: used by aggro.sh when GitHub App auth fails
+   export GITHUB_TOKEN_FALLBACK="fallback_token"
    ```
 
 3. **Validate your environment:**
@@ -151,6 +153,9 @@ To modify the merge behavior:
 Use `aggro.sh` when you need to aggressively merge branches without the usual
 safety checks. This script is intended for experimental workflows and will merge
 branches even when conflicts or failing checks exist.
+
+If GitHub App authentication fails, `aggro.sh` falls back to the token defined in
+`GITHUB_TOKEN_FALLBACK`.
 
 ```bash
 source /opt/scripts/auto-merge.env

--- a/aggro.sh
+++ b/aggro.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # AGGRESSIVE FORCE MERGE SCRIPT WITH GITHUB APP AUTHENTICATION
 # Performs 3 actions every minute: merge PR, force conflict merge, delete stale branch

--- a/check-log-size.sh
+++ b/check-log-size.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Log Size Monitoring Script for Force-Merge
 # Run this script weekly to check log file size

--- a/merge.sh
+++ b/merge.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Auto-merge script for all repositories
 # This script scans all repos and merges PRs/branches if no conflicts exist

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Setup script for environment variables
 # This script sets up the required environment variables for the auto-merge system
@@ -28,6 +29,6 @@ echo "  GITHUB_TOKEN: [REDACTED]"
 
 # Run the command passed as arguments
 if [ $# -gt 0 ]; then
-    echo "Executing: $@"
+    echo "Executing: $*"
     exec "$@"
 fi

--- a/update-automerge.sh
+++ b/update-automerge.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Auto-merge Update Script
 # Pulls latest changes from auto-merger repo and resets the cronjob
@@ -22,9 +23,7 @@ cd "$REPO_DIR" || {
 
 # Pull latest changes
 log "Pulling latest changes from auto-merger repository..."
-git pull origin main 2>&1 | tee -a "$LOG_FILE"
-
-if [ $? -eq 0 ]; then
+if git pull origin main 2>&1 | tee -a "$LOG_FILE"; then
     log "Successfully pulled latest changes"
 else
     log "WARNING: Git pull failed, continuing with existing version"
@@ -40,12 +39,10 @@ crontab -l > /tmp/crontab_backup_$(date +%Y%m%d_%H%M%S) 2>/dev/null
 crontab -l 2>/dev/null | grep -v "aggro.sh" > /tmp/new_crontab_temp
 
 # Add the updated automerge cronjob (every minute)
-echo "* * * * * cd $REPO_DIR && GITHUB_TOKEN=\"$GITHUB_TOKEN_VALUE\" GITHUB_USERNAME=\"$GITHUB_USERNAME\" ./aggro.sh >> /var/log/force-merge.log 2>&1" >> /tmp/new_crontab_temp
+printf '%s\n' "* * * * * cd $REPO_DIR && GITHUB_TOKEN=\"$GITHUB_TOKEN_VALUE\" GITHUB_USERNAME=\"$GITHUB_USERNAME\" ./aggro.sh >> /var/log/force-merge.log 2>&1" >> /tmp/new_crontab_temp
 
 # Install the new crontab
-crontab /tmp/new_crontab_temp
-
-if [ $? -eq 0 ]; then
+if crontab /tmp/new_crontab_temp; then
     log "Successfully updated crontab with latest automerge configuration"
 else
     log "ERROR: Failed to update crontab"


### PR DESCRIPTION
## Summary
- enable `set -euo pipefail` in all scripts
- document `GITHUB_TOKEN_FALLBACK` for aggro usage
- minor shell improvements and cron job update script tweaks

## Testing
- `bash -n merge.sh aggro.sh setup-env.sh check-log-size.sh update-automerge.sh`

------
https://chatgpt.com/codex/tasks/task_e_68712dbb8398833284735e01531cff67