### PR TITLE
Cleanup directories after run

### DIFF
--- a/aggro.sh
+++ b/aggro.sh
@@ -25,6 +25,17 @@ log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] FORCE-MERGE: $1" | tee -a "$LOG_FILE"
 }
 
+# Cleanup routine to ensure workspace is removed even on early exit
+cleanup() {
+    log "Cleaning up workspace..."
+    cd /
+    if [ -d "$WORKSPACE" ]; then
+        rm -rf "$WORKSPACE"
+    fi
+}
+
+trap cleanup EXIT
+
 # Check if we have a valid token
 if [ -z "$GITHUB_TOKEN" ]; then
     log "Error: No GitHub token available. Please check authentication setup."
@@ -189,14 +200,5 @@ main() {
     
     log "Force merge process completed - all repositories processed"
 }
-
-# Cleanup
-cleanup() {
-    log "Cleaning up workspace..."
-    cd /
-    rm -rf "$WORKSPACE"
-}
-
-trap cleanup EXIT
 
 main "$@"

--- a/merge.sh
+++ b/merge.sh
@@ -250,8 +250,10 @@ main() {
 # Cleanup function
 cleanup() {
     log "Cleaning up temporary files..."
-    # Optionally remove the temporary repo directory
-    # rm -rf "$REPO_DIR"
+    # Remove the temporary repository directory if it exists
+    if [ -d "$REPO_DIR" ]; then
+        rm -rf "$REPO_DIR"
+    fi
 }
 
 # Set up trap for cleanup


### PR DESCRIPTION
## Summary
- ensure temporary repo folder is removed in `merge.sh`
- add early cleanup trap for `$WORKSPACE` in `aggro.sh`

## Testing
- `./merge.sh >/tmp/merge.log`
- `./aggro.sh >/tmp/aggro.log`

------
https://chatgpt.com/codex/tasks/task_e_68712daba3748332abbc29f387cdf98f