### PR TITLE
Improve setup-env.sh robustness

### DIFF
--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,33 +1,34 @@
 #!/bin/bash
+set -euo pipefail
 
 # Setup script for environment variables
 # This script sets up the required environment variables for the auto-merge system
 
-# Check if auto-merge.env exists
-if [ -f "/opt/scripts/auto-merge.env" ]; then
-    echo "Loading environment variables from /opt/scripts/auto-merge.env"
-    source /opt/scripts/auto-merge.env
-else
-    echo "Warning: /opt/scripts/auto-merge.env not found"
-fi
+ENV_FILE="/opt/scripts/auto-merge.env"
 
-# Export required variables
-export GITHUB_TOKEN="${GITHUB_TOKEN}"
-export GITHUB_USERNAME="${GITHUB_USERNAME}"
-
-# Check if variables are set
-if [ -z "$GITHUB_TOKEN" ] || [ -z "$GITHUB_USERNAME" ]; then
-    echo "Error: Required environment variables are not set"
-    echo "Please ensure GITHUB_TOKEN and GITHUB_USERNAME are defined in /opt/scripts/auto-merge.env"
+# Ensure environment file exists
+if [[ ! -f "$ENV_FILE" ]]; then
+    echo "Error: Environment file $ENV_FILE not found." >&2
+    echo "Create the file with GITHUB_TOKEN and GITHUB_USERNAME variables." >&2
     exit 1
 fi
+
+echo "Loading environment variables from $ENV_FILE"
+# shellcheck source=/opt/scripts/auto-merge.env
+source "$ENV_FILE"
+
+# Validate required variables
+: "${GITHUB_TOKEN:?Error: GITHUB_TOKEN is not set or empty in $ENV_FILE}"
+: "${GITHUB_USERNAME:?Error: GITHUB_USERNAME is not set or empty in $ENV_FILE}"
+
+export GITHUB_TOKEN GITHUB_USERNAME
 
 echo "Environment variables set successfully:"
 echo "  GITHUB_USERNAME: $GITHUB_USERNAME"
 echo "  GITHUB_TOKEN: [REDACTED]"
 
 # Run the command passed as arguments
-if [ $# -gt 0 ]; then
-    echo "Executing: $@"
+if [ "$#" -gt 0 ]; then
+    echo "Executing: $*"
     exec "$@"
 fi


### PR DESCRIPTION
## Summary
- enable strict mode in `setup-env.sh`
- stop if the env file is missing or variables are unset
- keep a clear message when executing a command through the script

## Testing
- `bash -n setup-env.sh`
- `./setup-env.sh` (with missing env file)

------
https://chatgpt.com/codex/tasks/task_e_68712d9e128883328dcd42504f08acc6